### PR TITLE
Added implementation of GetBrowseNodes to the AmazonProductAdvertisingClient

### DIFF
--- a/src/Nager.AmazonProductAdvertising/AmazonEndpoint.cs
+++ b/src/Nager.AmazonProductAdvertising/AmazonEndpoint.cs
@@ -61,5 +61,13 @@
         /// United States
         /// </summary>
         US,
+        /// <summary>
+        /// Netherlands
+        /// </summary>
+        NL,  
+        /// <summary>
+        /// Singapore
+        /// </summary>
+        SG, 
     }
 }

--- a/src/Nager.AmazonProductAdvertising/AmazonLanguageValidator.cs
+++ b/src/Nager.AmazonProductAdvertising/AmazonLanguageValidator.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.Linq;
+using System;
+namespace Nager.AmazonProductAdvertising
+{
+    public class AmazonLanguageValidator
+    {
+       private readonly Dictionary<string, AmazonEndpoint[]> _languages;
+
+        /// <summary>
+        /// Amazon Valid Languages Validator
+        /// </summary>
+        public AmazonLanguageValidator()
+        {
+            this._languages = new Dictionary<string, AmazonEndpoint[]>
+            {
+                { "cs_CZ", new [] { AmazonEndpoint.DE } },
+                { "de_DE", new [] { AmazonEndpoint.DE, AmazonEndpoint.US } },
+                { "en_GB", new [] { AmazonEndpoint.DE, AmazonEndpoint.UK } },
+                { "nl_NL", new [] { AmazonEndpoint.DE, AmazonEndpoint.NL } },
+                { "pl_PL", new [] { AmazonEndpoint.DE } },
+                { "tr_TR", new [] { AmazonEndpoint.DE, AmazonEndpoint.TR } },
+                { "en_AU", new [] { AmazonEndpoint.AU } },
+                { "pt_BR", new [] { AmazonEndpoint.BR, AmazonEndpoint.US } },
+                { "en_CA", new [] { AmazonEndpoint.CA } },
+                { "fr_CA", new [] { AmazonEndpoint.CA } },
+                { "fr_FR", new [] { AmazonEndpoint.FR } },
+                { "en_IN", new [] { AmazonEndpoint.IN } },
+                { "it_IT", new [] { AmazonEndpoint.IT } },
+                { "ja_JP", new [] { AmazonEndpoint.JP } },
+                { "zh_CN", new [] { AmazonEndpoint.JP, AmazonEndpoint.US } },
+                { "es_MX", new [] { AmazonEndpoint.MX } },
+                { "en_SG", new [] { AmazonEndpoint.SG } },
+                { "es_ES", new [] { AmazonEndpoint.ES } },
+                { "en_AE", new [] { AmazonEndpoint.AE } },
+                { "ar_AE", new [] { AmazonEndpoint.AE } },
+                { "en_US", new [] { AmazonEndpoint.JP, AmazonEndpoint.US } },
+                { "es_US", new [] { AmazonEndpoint.US } },
+                { "ko_KR", new [] { AmazonEndpoint.US } },
+                { "zh_TW", new [] { AmazonEndpoint.US } },
+            };
+        }
+
+        /// <summary>
+        /// Check languages are valid for endpoint
+        /// See https://webservices.amazon.com/paapi5/documentation/locale-reference.html for more information.
+        /// </summary>
+        /// <param name="languages"></param>
+        /// <param name="endpoint"></param>
+        /// <returns></returns>
+        public bool IsLanguageValid(string[] languages, AmazonEndpoint endpoint)
+        {
+            if (languages == null)
+            {
+                return false;
+            }
+
+            var items = this._languages.Count(language => 
+                languages.Any(x => language.Key.Equals(x, System.StringComparison.OrdinalIgnoreCase) && 
+                language.Value.Any(y => y.Equals(endpoint)))
+            );
+
+            return items == languages.Length;
+        }
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/BrowseNodesRequest.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/BrowseNodesRequest.cs
@@ -1,0 +1,9 @@
+namespace Nager.AmazonProductAdvertising.Model
+{
+    public class BrowseNodesRequest
+    {
+        public string[] BrowseNodeIds { get; set; }
+        public string[] LanguagesOfPreference { get; set; }
+        public string[] Resources { get; set; }
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/GetBrowseNodesResponse.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/GetBrowseNodesResponse.cs
@@ -1,0 +1,8 @@
+using Nager.AmazonProductAdvertising.Model.Paapi;
+namespace Nager.AmazonProductAdvertising.Model
+{
+    public class GetBrowseNodesResponse : AmazonResponse
+    {
+        public BrowseNodesResult BrowseNodesResult { get; set; }
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNode2.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNode2.cs
@@ -1,0 +1,13 @@
+namespace Nager.AmazonProductAdvertising.Model.Paapi
+{
+    public class BrowseNode2
+    {
+        public string Id { get; set; }
+        public bool IsRoot { get; set; }
+        public string ContextFreeName { get; set; }
+        public string DisplayName { get; set; }
+        public AncestorInfo Ancestor { get; set; }
+        public int SalesRank { get; set; }
+        public BrowseNodeChild[] Children { get; set; }
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNodeChild.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNodeChild.cs
@@ -1,0 +1,9 @@
+namespace Nager.AmazonProductAdvertising.Model.Paapi
+{
+    public class BrowseNodeChild
+    {
+        public string Id { get; set; }
+        public string ContextFreeName { get; set; }
+        public string DisplayName { get; set; }   
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNodesResult.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/Paapi/BrowseNodesResult.cs
@@ -1,0 +1,7 @@
+namespace Nager.AmazonProductAdvertising.Model.Paapi
+{
+    public class BrowseNodesResult
+    {
+        public BrowseNode2[] BrowseNodes { get; set; }
+    }
+}

--- a/src/Nager.AmazonProductAdvertising/Model/Request/GetBrowseNodesRequest.cs
+++ b/src/Nager.AmazonProductAdvertising/Model/Request/GetBrowseNodesRequest.cs
@@ -1,0 +1,8 @@
+namespace Nager.AmazonProductAdvertising.Model.Request
+{
+    public class GetBrowseNodesRequest : AmazonRequest
+    {
+        public string[] BrowseNodeIds { get; set; }
+        public string[] LanguagesOfPreference { get; set; }
+    }
+}


### PR DESCRIPTION
Solves #125 

Thank you for this awesome Amazon paapi5 client. I need to use the GetBrowseNodes operation in one of my projects and therefore added an implementation of it to your client.

I found it necessary to add an extra BrowseNode2 class because BrowseNode response objects from GetBrowseNodes operations have the additional property "Children".

Should I also provide some unit tests?